### PR TITLE
Delete orphaned routes for nodes whose deletion was missed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.18.5 AS builder
+FROM golang:1.19.1 AS builder
 
 WORKDIR /build
 COPY . .

--- a/pkg/updater/routes.go
+++ b/pkg/updater/routes.go
@@ -110,21 +110,20 @@ outer:
 		if route.Origin != nil && *route.Origin != ec2.RouteOriginCreateRoute {
 			continue
 		}
-		if route.InstanceId == nil && route.DestinationCidrBlock == nil {
+		if route.DestinationCidrBlock == nil {
 			continue
 		}
 		if _, ipnet, err := net.ParseCIDR(*route.DestinationCidrBlock); err != nil || !r.podNetwork.Contains(ipnet.IP) {
 			continue
 		}
 		for i, nr := range nodeRoutes {
-			if nr.PodCIDR == *route.DestinationCidrBlock && nr.InstanceID == *route.InstanceId {
+			if nr.PodCIDR == *route.DestinationCidrBlock && route.InstanceId != nil && nr.InstanceID == *route.InstanceId {
 				found[i] = true
 				continue outer
 			}
 		}
 		toBeDeleted = append(toBeDeleted, internalNodeRoute{
 			destinationCidrBlock: *route.DestinationCidrBlock,
-			instanceId:           *route.InstanceId,
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If the AWS custom route controller is not running when a node is been deleted, its route for the pod CIDR may become orphaned with status "blackholed". This can become a problem if the pod CIDR is reused for another node.
With this fix, such orphaned routes are deleted.

Additionally the golang build image version was upgraded from `v1.18.5` to `v1.19.1`. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Delete orphaned routes for nodes whose deletion was missed.
```
