### PR TITLE
Healthz check should succeed during waiting for leader lease

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	reconciler := controller.NewNodeReconciler()
+	reconciler := controller.NewNodeReconciler(mgr.Elected())
 	err = builder.
 		ControllerManagedBy(mgr).
 		For(&corev1.Node{}).


### PR DESCRIPTION
**What this PR does / why we need it**:
If the leader election is enabled (e.g. for HA control plane), the healthz check should succeed during the pod is waiting for the leader lease. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Healthz check should succeed during waiting for leader lease
```
