### PR TITLE
Try all route update ops before returning errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.24.1
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/atomic v1.10.0
+	go.uber.org/multierr v1.8.0
 	golang.org/x/tools v0.1.12
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
@@ -51,7 +52,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.2.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
To reduce the impact of a failed route deletion or creation operation, all route updates are executed, even if any of them fails.
In this way, new routes are added even if a deletion fails (which should not happen, but have already been seen).

It should slightly improve robustness, but will not resolve any problem if the route of a deleted node cannot be deleted and its pod CIDR is reused by a new node.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Try all route update operations on all route tables before returning errors
```

/cc @kon-angelo 