### PR TITLE
Create events on route updates failures and don't keep node routes to main route table

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -18,12 +18,13 @@ aws-custom-route-controller:
             dockerfile: 'Dockerfile'
     steps:
       verify:
-        image: golang:1.19.4
+        image: golang:1.19.5
   jobs:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
+        component_descriptor:
+          retention_policy: 'clean-snapshots'
     pull-request:
       traits:
         pull-request: ~

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.19.4 AS builder
+FROM golang:1.19.5 AS builder
 
 WORKDIR /build
 COPY . .

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ import (
 var Version string
 
 const (
+	// componentName is the component name
+	componentName = "aws-custom-route-controller"
 	// leaderElectionId is the name of the lease resource
 	leaderElectionId = "aws-custom-route-controller-leader-election"
 )
@@ -51,7 +53,7 @@ var (
 func main() {
 	logf.SetLogger(zap.New())
 
-	var log = logf.Log.WithName("aws-custom-route-controller")
+	var log = logf.Log.WithName(componentName)
 	log.Info("version", "version", Version)
 
 	pflag.Parse()
@@ -81,7 +83,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	reconciler := controller.NewNodeReconciler(mgr.Elected())
+	reconciler := controller.NewNodeReconciler(mgr.Elected(), mgr.GetEventRecorderFor(componentName))
 	err = builder.
 		ControllerManagedBy(mgr).
 		For(&corev1.Node{}).

--- a/pkg/updater/ec2.go
+++ b/pkg/updater/ec2.go
@@ -67,3 +67,12 @@ func hasClusterTag(clusterID string, tags []*ec2.Tag) bool {
 	}
 	return false
 }
+
+func getNameTagValue(tags []*ec2.Tag) string {
+	for _, tag := range tags {
+		if aws.StringValue(tag.Key) == "Name" {
+			return aws.StringValue(tag.Value)
+		}
+	}
+	return ""
+}

--- a/pkg/updater/routes.go
+++ b/pkg/updater/routes.go
@@ -106,7 +106,14 @@ func (r *CustomRoutes) Update(routes []NodeRoute) error {
 	return updateErrors
 }
 
+func (r *CustomRoutes) isMainTable(table *ec2.RouteTable) bool {
+	return getNameTagValue(table.Tags) == r.clusterName
+}
+
 func (r *CustomRoutes) calcRouteChanges(table *ec2.RouteTable, nodeRoutes []NodeRoute) (toBeCreated, toBeDeleted []internalNodeRoute) {
+	if r.isMainTable(table) {
+		nodeRoutes = nil
+	}
 	found := make([]bool, len(nodeRoutes))
 outer:
 	for _, route := range table.Routes {


### PR DESCRIPTION
**What this PR does / why we need it**:
Events are now created in the `kube-system` namespace on route updates, especially if they are failing.
Note, that on normal operation the event is created only once.
If the route update has errors, the event is created everytime. As soon as it recovers an event for normal operation is created one time.
These events will be analysed by a health check of the provider-aws extension.

Additionally, the main table will not contain the routes to the worker nodes anymore. It is sufficient to have them in the route tables for the subnets. If the VPC is used by multiple clusters, keeping the routes in the main table would cause quota issues (`RouteLimitExceeded`) just sooner. There is a hard limit of 1000 routes per route table according to the AWS documentation, see [Amazon VPC quotas](https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Create events on route updates failures and don't keep node routes to main route table
```
