### PR TITLE
bump builder image to golang:1.20.2

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,7 +24,7 @@ aws-custom-route-controller:
             dockerfile: 'Dockerfile'
     steps:
       verify:
-        image: golang:1.19.5
+        image: golang:1.20.2
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.19.5 AS builder
+FROM golang:1.20.2 AS builder
 
 WORKDIR /build
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/aws-custom-route-controller
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.42.25


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump builder image to golang:1.20.2

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bump builder image from `golang:1.19.5` to `golang:1.20.2`
```
