### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,6 +2,8 @@ aws-custom-route-controller:
   base_definition:
     traits:
       component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        component_name: github.com/gardener/aws-custom-route-controller
         component_labels:
         - name: 'cloud.gardener.cnudie/responsibles'
           value:
@@ -17,7 +19,7 @@ aws-custom-route-controller:
             inputs:
               repos:
                 source: ~ # default
-            image: 'eu.gcr.io/gardener-project/gardener/aws-custom-route-controller'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/aws-custom-route-controller
             dockerfile: 'Dockerfile'
     steps:
       verify:
@@ -25,6 +27,9 @@ aws-custom-route-controller:
   jobs:
     head-update:
       traits:
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -33,6 +38,12 @@ aws-custom-route-controller:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            aws-custom-route-controller:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/aws-custom-route-controller
         release:
           nextversion: 'bump_minor'
         slack:
@@ -41,5 +52,3 @@ aws-custom-route-controller:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
-        component_descriptor:
-          component_name: 'github.com/gardener/aws-custom-route-controller'

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY              := eu.gcr.io/gardener-project
+REGISTRY              := europe-docker.pkg.dev/gardener-project/public
 EXECUTABLE            := aws-custom-route-controller
 PROJECT               := github.com/gardener/aws-custom-route-controller
 IMAGE_REPOSITORY      := $(REGISTRY)/gardener/aws-custom-route-controller


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
