### PR TITLE
Update golangci-lint to v1.61 with golang v1.23 support and remove old rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,6 @@
 run:
   concurrency: 4
   deadline: 10m
-  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
-  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
-  go: "1.17"
 
 linters:
   disable:

--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -35,7 +35,7 @@ clean-tools-bin:
 	rm -rf $(TOOLS_BIN_DIR)/*
 
 # default tool versions
-GOLANGCI_LINT_VERSION ?= v1.55.1
+GOLANGCI_LINT_VERSION ?= v1.61.0
 
 GOIMPORTS_VERSION ?= $(call version_gomod,golang.org/x/tools)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update golangci-lint to v1.61 with golang v1.23 support and remove old rule.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
