### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 .cache_ggshield
 .gitguardian.yaml
 
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,14 @@ docker-images-linux-amd64:
 generate: $(MOCKGEN)
 	@MOCKGEN=$(shell realpath $(MOCKGEN)) go generate ./pkg/...
 
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@./hack/sast.sh --gosec-report true
+
 # Run tests
 .PHONY: test
 test:
@@ -66,4 +74,4 @@ update-dependencies:
 	@make tidy
 
 .PHONY: verify
-verify: check format test
+verify: check format test sast-report

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/aws-custom-route-controller
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go v1.49.11

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...
+

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec
+

--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -6,6 +6,9 @@ TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
 GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
 MOCKGEN                    := $(TOOLS_BIN_DIR)/mockgen
+GOSEC                      := $(TOOLS_BIN_DIR)/gosec
+
+export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 
 #########################################
 # Common                                #
@@ -35,7 +38,10 @@ clean-tools-bin:
 	rm -rf $(TOOLS_BIN_DIR)/*
 
 # default tool versions
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.61.0
+# renovate: datasource=github-releases depName=securego/gosec
+GOSEC_VERSION ?= v2.20.0
 
 GOIMPORTS_VERSION ?= $(call version_gomod,golang.org/x/tools)
 
@@ -49,3 +55,6 @@ $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERS
 
 $(MOCKGEN): go.mod
 	go build -o $(MOCKGEN) github.com/golang/mock/mockgen
+
+$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+	@GOSEC_VERSION=$(GOSEC_VERSION) $(TOOLS_DIR)/install-gosec.sh


### PR DESCRIPTION
/area networking
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:

This PR introduces `gosec` for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of `gosec` similar to what was introduced to gardener/gardener in https://github.com/gardener/gardener/pull/9959.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`gosec` was introduced for Static Application Security Testing (SAST).
```
