### PR TITLE
support dual-stack

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,10 +6,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gardener/aws-custom-route-controller/pkg/controller"
 	"github.com/gardener/aws-custom-route-controller/pkg/updater"
+	"github.com/gardener/aws-custom-route-controller/pkg/util"
 	"github.com/gardener/aws-custom-route-controller/pkg/util/logger"
 
 	"github.com/go-logr/logr"
@@ -121,7 +123,13 @@ func main() {
 		log.Error(err, "could not create AWS EC2 interface")
 		os.Exit(1)
 	}
-	customRoutes, err := updater.NewCustomRoutes(log.WithName("updater"), ec2Routes, *clusterName, *podNetworkCidr)
+	podCIDR, err := util.GetIPv4CIDR(strings.Split(*podNetworkCidr, ","))
+	if err != nil {
+		log.Error(err, "could not parse IPv4 address from pod-network-cidr")
+		os.Exit(1)
+	}
+
+	customRoutes, err := updater.NewCustomRoutes(log.WithName("updater"), ec2Routes, *clusterName, podCIDR)
 	if err != nil {
 		log.Error(err, "could not create AWS custom routes updater")
 		os.Exit(1)

--- a/pkg/updater/node_route.go
+++ b/pkg/updater/node_route.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/gardener/aws-custom-route-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -114,7 +115,8 @@ func extractNodeRoute(node *corev1.Node) *NodeRoute {
 		return nil
 	}
 	_, instanceID, _ := decodeRegionAndInstanceID(node.Spec.ProviderID)
-	return NewNodeRoute(instanceID, node.Spec.PodCIDR)
+	podCIDR, _ := util.GetIPv4CIDR(node.Spec.PodCIDRs)
+	return NewNodeRoute(instanceID, podCIDR)
 }
 
 // decodeRegionAndInstanceID extracts region and instanceID
@@ -125,7 +127,7 @@ func decodeRegionAndInstanceID(providerID string) (string, string, error) {
 	}
 	splitProviderID := strings.Split(providerID, "/")
 	if len(splitProviderID) < 2 {
-		err := fmt.Errorf("Unable to decode provider-ID")
+		err := fmt.Errorf("unable to decode provider-ID")
 		return "", "", err
 	}
 	return splitProviderID[len(splitProviderID)-2], splitProviderID[len(splitProviderID)-1], nil

--- a/pkg/updater/node_route_test.go
+++ b/pkg/updater/node_route_test.go
@@ -14,35 +14,35 @@ import (
 
 var _ = Describe("NamedNodeRoutes", func() {
 	var (
-		podCIDR1        = "10.0.1.0/24"
+		podCIDRs1       = []string{"10.0.1.0/24"}
 		node1InstanceID = "i-0001"
 		node1           = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node1",
 			},
 			Spec: corev1.NodeSpec{
-				PodCIDR:    podCIDR1,
+				PodCIDRs:   podCIDRs1,
 				ProviderID: makeProviderID(node1InstanceID),
 			},
 		}
-		podCIDR2        = "10.0.7.0/24"
+		podCIDRs2       = []string{"10.0.7.0/24"}
 		node2InstanceID = "i-0001"
 		node2           = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node2",
 			},
 			Spec: corev1.NodeSpec{
-				PodCIDR:    podCIDR2,
+				PodCIDRs:   podCIDRs2,
 				ProviderID: makeProviderID(node2InstanceID),
 			},
 		}
-		podCIDR3 = "10.0.33.0/24"
-		node3    = &corev1.Node{
+		podCIDRs3 = []string{"10.0.33.0/24"}
+		node3     = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node3",
 			},
 			Spec: corev1.NodeSpec{
-				PodCIDR: podCIDR3,
+				PodCIDRs: podCIDRs3,
 			},
 		}
 	)
@@ -50,14 +50,14 @@ var _ = Describe("NamedNodeRoutes", func() {
 	It("should extract node data", func() {
 		routes := updater.NewNamedNodeRoutes()
 		route1, changed1 := routes.AddNodeRoute(node1)
-		Expect(route1).To(Equal(updater.NewNodeRoute(node1InstanceID, podCIDR1)))
+		Expect(route1).To(Equal(updater.NewNodeRoute(node1InstanceID, podCIDRs1[0])))
 		Expect(changed1).To(BeTrue())
 		route1b, changed1b := routes.AddNodeRoute(node1)
 		Expect(route1b).NotTo(BeNil())
 		Expect(changed1b).To(BeFalse())
 
 		route2, changed2 := routes.AddNodeRoute(node2)
-		Expect(route2).To(Equal(updater.NewNodeRoute(node2InstanceID, podCIDR2)))
+		Expect(route2).To(Equal(updater.NewNodeRoute(node2InstanceID, podCIDRs2[0])))
 		Expect(changed2).To(BeTrue())
 
 		route3, changed3 := routes.AddNodeRoute(node3)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+	"net"
+)
+
+// GetIPv4CIDR returns an IPv4 CIDR
+func GetIPv4CIDR(cidrs []string) (string, error) {
+	for _, cidr := range cidrs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			err := fmt.Errorf("unable to parse cidr: %s", cidr)
+			return "", err
+		}
+		if ipNet.IP.To4() != nil {
+			return cidr, nil
+		}
+	}
+	return "", nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Add dual-stack support. 
The `aws-custom-route-controller` only adds node routes for IPv4 pod CIDR ranges and does not interfere with IPv6 routes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `aws-custom-route-controller` only adds node routes for IPv4 pod CIDR ranges and does not interfere with IPv6 routes.
```
