### PR TITLE
Enable multi-arch build

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,6 +21,9 @@ aws-custom-route-controller:
           'inject-commit-hash'
       publish:
         oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           aws-custom-route-controller:
             inputs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable multi-arch build for ARM64 images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Introduce multi-arch build for `linux/arm64` images.
```
