### PR TITLE
Ignore aws-sdk-go-v2 dependencies of `aws-sdk-go-v2/config`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    ignore:
+      # Ignore updates for the following AWS dependencies as they are implicitly updated by "github.com/aws/aws-sdk-go-v2/config"
+      - dependency-name: "github.com/aws/aws-sdk-go-v2"
+      - dependency-name: "github.com/aws/aws-sdk-go-v2/credentials"
+      - dependency-name: "github.com/aws/aws-sdk-go-v2/service/sts"
+
   # Create PRs for golang version updates
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore `github.com/aws/aws-sdk-go-v2/*` dependencies of `github.com/aws/aws-sdk-go-v2/config` to reduce number of PRs.
The ignored dependencies are updated indirectly with the config dependency.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
