### PR TITLE
Update base image to `debian12`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 RUN make release GOARCH=$TARGETARCH
 
 ############# aws-custom-route-controller
-FROM gcr.io/distroless/static-debian11:nonroot AS aws-custom-route-controller
+FROM gcr.io/distroless/static-debian12:nonroot AS aws-custom-route-controller
 
 COPY --from=builder /build/aws-custom-route-controller /aws-custom-route-controller
 ENTRYPOINT ["/aws-custom-route-controller"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Update base image from `debian11` to `debian12` to get current set of CA certificates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update base image from `debian11` to `debian12`.
```
