### PR TITLE
Ensure the healthz tick is updated during long running update

### DIFF
--- a/pkg/updater/node_route.go
+++ b/pkg/updater/node_route.go
@@ -46,7 +46,7 @@ func (r NodeRoute) Equals(other *NodeRoute) bool {
 	return r == *other
 }
 
-type NodeRoutesUpdater func(ctx context.Context, routes []NodeRoute) error
+type NodeRoutesUpdater func(ctx context.Context, routes []NodeRoute, tick func()) error
 
 type NamedNodeRoutes struct {
 	sync.Mutex

--- a/pkg/updater/routes_test.go
+++ b/pkg/updater/routes_test.go
@@ -125,7 +125,7 @@ var _ = Describe("CustomRoutes", func() {
 
 	It("should report error if no route tables found", func() {
 		ec2RoutesMock.EXPECT().DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{}).Return(&ec2.DescribeRouteTablesOutput{}, nil)
-		err := customRoutes.Update(ctx, nil)
+		err := customRoutes.Update(ctx, nil, func() {})
 		Expect(err).NotTo(BeNil())
 	})
 
@@ -150,13 +150,13 @@ var _ = Describe("CustomRoutes", func() {
 			InstanceId:           aws.String(nodeRoutes[1].InstanceID),
 			RouteTableId:         rt2,
 		})
-		err := customRoutes.Update(ctx, nodeRoutes)
+		err := customRoutes.Update(ctx, nodeRoutes, func() {})
 		Expect(err).To(BeNil())
 	})
 
 	It("should update nothing if unchanged", func() {
 		ec2RoutesMock.EXPECT().DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{}).Return(&ec2.DescribeRouteTablesOutput{RouteTables: tables2}, nil)
-		err := customRoutes.Update(ctx, nodeRoutes)
+		err := customRoutes.Update(ctx, nodeRoutes, func() {})
 		Expect(err).To(BeNil())
 	})
 


### PR DESCRIPTION
…

**What this PR does / why we need it**:
-  In edge cases it can happen, that the healthz check fails, as the internal tick is not updated during all the route tables are updated. Especially if errors like `RouteLimitExceeded` are returned, the execution of all calls can take up to several minutes. With this change, the tick is updated between the various API calls.
- log the reason for healthz failure

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
