### PR TITLE
Support multi-NIC route creation using NetworkInterfaceId

### DIFF
--- a/pkg/updater/ec2.go
+++ b/pkg/updater/ec2.go
@@ -37,6 +37,7 @@ type EC2Routes interface {
 	DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
 	CreateRoute(ctx context.Context, params *ec2.CreateRouteInput, optFns ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error)
 	DeleteRoute(ctx context.Context, params *ec2.DeleteRouteInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteOutput, error)
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
 }
 
 func NewAWSEC2Routes(creds *Credentials, region string) (EC2Routes, error) {

--- a/pkg/updater/mock_ec2.go
+++ b/pkg/updater/mock_ec2.go
@@ -75,6 +75,26 @@ func (mr *MockEC2RoutesMockRecorder) DeleteRoute(arg0, arg1 interface{}, arg2 ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoute", reflect.TypeOf((*MockEC2Routes)(nil).DeleteRoute), varargs...)
 }
 
+// DescribeInstances mocks base method.
+func (m *MockEC2Routes) DescribeInstances(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeInstances", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeInstances indicates an expected call of DescribeInstances.
+func (mr *MockEC2RoutesMockRecorder) DescribeInstances(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockEC2Routes)(nil).DescribeInstances), varargs...)
+}
+
 // DescribeRouteTables mocks base method.
 func (m *MockEC2Routes) DescribeRouteTables(arg0 context.Context, arg1 *ec2.DescribeRouteTablesInput, arg2 ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/updater/routes.go
+++ b/pkg/updater/routes.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -72,6 +73,45 @@ func (r *CustomRoutes) findRouteTables(ctx context.Context) ([]ec2types.RouteTab
 	return tables, nil
 }
 
+func (r *CustomRoutes) getNetworkInterfaces(ctx context.Context, instanceID string) ([]string, error) {
+	request := &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	}
+	response, err := r.ec2.DescribeInstances(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response.Reservations) == 0 || len(response.Reservations[0].Instances) == 0 {
+		return nil, fmt.Errorf("instance %s not found", instanceID)
+	}
+
+	instance := response.Reservations[0].Instances[0]
+
+	// Sort network interfaces by device index so primary ENI (device 0) is first
+	enis := instance.NetworkInterfaces
+	sort.Slice(enis, func(i, j int) bool {
+		di := int32(0)
+		dj := int32(0)
+		if enis[i].Attachment != nil && enis[i].Attachment.DeviceIndex != nil {
+			di = *enis[i].Attachment.DeviceIndex
+		}
+		if enis[j].Attachment != nil && enis[j].Attachment.DeviceIndex != nil {
+			dj = *enis[j].Attachment.DeviceIndex
+		}
+		return di < dj
+	})
+
+	var networkInterfaceIds []string
+	for _, eni := range enis {
+		if eni.NetworkInterfaceId != nil {
+			networkInterfaceIds = append(networkInterfaceIds, *eni.NetworkInterfaceId)
+		}
+	}
+
+	return networkInterfaceIds, nil
+}
+
 // Update updates all found route tables (tagged with the clusterName) with the podCIDR to node instance routes
 // Returns a RouteUpdateResult that tracks which routes were successfully created
 func (r *CustomRoutes) Update(ctx context.Context, routes []NodeRoute, tick func()) (*RouteUpdateResult, error) {
@@ -110,20 +150,52 @@ func (r *CustomRoutes) Update(ctx context.Context, routes []NodeRoute, tick func
 		}
 
 		for _, create := range toBeCreated {
-			req := &ec2.CreateRouteInput{
-				DestinationCidrBlock: aws.String(create.destinationCidrBlock),
-				InstanceId:           aws.String(create.instanceId),
-				RouteTableId:         table.RouteTableId,
-			}
-			tick()
-			_, err = r.ec2.CreateRoute(ctx, req)
+			networkInterfaceIds, err := r.getNetworkInterfaces(ctx, create.instanceId)
 			if err != nil {
-				updateErrors = multierr.Append(updateErrors, fmt.Errorf("creating route %s -> %s in table %s failed: %w", create.destinationCidrBlock, create.instanceId, *table.RouteTableId, err))
+				updateErrors = multierr.Append(updateErrors, fmt.Errorf("getting network interfaces for instance %s failed: %w", create.instanceId, err))
 				result.SuccessfulRoutes[create.destinationCidrBlock] = false
 				continue
 			}
-			result.SuccessfulRoutes[create.destinationCidrBlock] = true
-			r.log.Info("route created", "table", *table.RouteTableId, "destination", create.destinationCidrBlock, "instanceId", create.instanceId)
+
+			// Multi-NIC instances: AWS rejects InstanceId in CreateRoute, must use NetworkInterfaceId.
+			// Try each ENI (sorted by device index), first success wins.
+			if len(networkInterfaceIds) > 1 {
+				routeCreated := false
+				for _, eniId := range networkInterfaceIds {
+					req := &ec2.CreateRouteInput{
+						DestinationCidrBlock: aws.String(create.destinationCidrBlock),
+						NetworkInterfaceId:   aws.String(eniId),
+						RouteTableId:         table.RouteTableId,
+					}
+					tick()
+					_, err = r.ec2.CreateRoute(ctx, req)
+					if err == nil {
+						r.log.Info("route created", "table", *table.RouteTableId, "destination", create.destinationCidrBlock, "instanceId", create.instanceId, "networkInterfaceId", eniId)
+						routeCreated = true
+						break
+					}
+				}
+				if !routeCreated {
+					updateErrors = multierr.Append(updateErrors, fmt.Errorf("creating route %s -> %s in table %s failed on all ENIs", create.destinationCidrBlock, create.instanceId, *table.RouteTableId))
+				}
+				result.SuccessfulRoutes[create.destinationCidrBlock] = routeCreated
+			} else {
+				// Single NIC: use InstanceId as before
+				req := &ec2.CreateRouteInput{
+					DestinationCidrBlock: aws.String(create.destinationCidrBlock),
+					InstanceId:           aws.String(create.instanceId),
+					RouteTableId:         table.RouteTableId,
+				}
+				tick()
+				_, err = r.ec2.CreateRoute(ctx, req)
+				if err != nil {
+					updateErrors = multierr.Append(updateErrors, fmt.Errorf("creating route %s -> %s in table %s failed: %w", create.destinationCidrBlock, create.instanceId, *table.RouteTableId, err))
+					result.SuccessfulRoutes[create.destinationCidrBlock] = false
+					continue
+				}
+				result.SuccessfulRoutes[create.destinationCidrBlock] = true
+				r.log.Info("route created", "table", *table.RouteTableId, "destination", create.destinationCidrBlock, "instanceId", create.instanceId)
+			}
 		}
 
 		// Mark routes that already exist (not in toBeCreated) as successful

--- a/pkg/updater/routes_test.go
+++ b/pkg/updater/routes_test.go
@@ -135,16 +135,67 @@ var _ = Describe("CustomRoutes", func() {
 			DestinationCidrBlock: routeNode2.DestinationCidrBlock,
 			RouteTableId:         rt1,
 		})
+		// Mock DescribeInstances for node3 on rt1
+		ec2RoutesMock.EXPECT().DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			InstanceIds: []string{nodeRoutes[1].InstanceID},
+		}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{
+				{
+					Instances: []ec2types.Instance{
+						{
+							InstanceId: aws.String(nodeRoutes[1].InstanceID),
+							NetworkInterfaces: []ec2types.InstanceNetworkInterface{
+								{NetworkInterfaceId: aws.String("eni-node3")},
+							},
+						},
+					},
+				},
+			},
+		}, nil)
 		ec2RoutesMock.EXPECT().CreateRoute(ctx, &ec2.CreateRouteInput{
 			DestinationCidrBlock: aws.String(nodeRoutes[1].PodCIDR),
 			InstanceId:           aws.String(nodeRoutes[1].InstanceID),
 			RouteTableId:         rt1,
 		})
+		// Mock DescribeInstances for node1 on rt2
+		ec2RoutesMock.EXPECT().DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			InstanceIds: []string{nodeRoutes[0].InstanceID},
+		}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{
+				{
+					Instances: []ec2types.Instance{
+						{
+							InstanceId: aws.String(nodeRoutes[0].InstanceID),
+							NetworkInterfaces: []ec2types.InstanceNetworkInterface{
+								{NetworkInterfaceId: aws.String("eni-node1")},
+							},
+						},
+					},
+				},
+			},
+		}, nil)
 		ec2RoutesMock.EXPECT().CreateRoute(ctx, &ec2.CreateRouteInput{
 			DestinationCidrBlock: aws.String(nodeRoutes[0].PodCIDR),
 			InstanceId:           aws.String(nodeRoutes[0].InstanceID),
 			RouteTableId:         rt2,
 		})
+		// Mock DescribeInstances for node3 on rt2
+		ec2RoutesMock.EXPECT().DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			InstanceIds: []string{nodeRoutes[1].InstanceID},
+		}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{
+				{
+					Instances: []ec2types.Instance{
+						{
+							InstanceId: aws.String(nodeRoutes[1].InstanceID),
+							NetworkInterfaces: []ec2types.InstanceNetworkInterface{
+								{NetworkInterfaceId: aws.String("eni-node3")},
+							},
+						},
+					},
+				},
+			},
+		}, nil)
 		ec2RoutesMock.EXPECT().CreateRoute(ctx, &ec2.CreateRouteInput{
 			DestinationCidrBlock: aws.String(nodeRoutes[1].PodCIDR),
 			InstanceId:           aws.String(nodeRoutes[1].InstanceID),


### PR DESCRIPTION
/area networking
/kind enhancement

**What this PR does / why we need it**:

Adds support for creating VPC routes on instances with multiple network interfaces (multi-NIC GPU instances like p4d.24xlarge). AWS rejects CreateRoute with InstanceId for multi-NIC instances, so the controller now uses NetworkInterfaceId instead.

Changes:
- Use NetworkInterfaceId for CreateRoute on multi-NIC instances (first success wins)
- Sort ENIs by device index (primary ENI tried first)
- Add DescribeInstances to EC2Routes interface for ENI discovery
- Single-NIC instances continue using InstanceId (backward compatible)

**Which issue(s) this PR fixes**:
Fixes #483

**Special notes for your reviewer**:
- Related to gardener/gardener-extension-provider-aws#1791 (EFA network interface support)

**Locally tested cases**:

- [x] p4d.24xlarge routes created with NetworkInterfaceId
- [x] m5.large routes created with InstanceId (single-NIC fallback)
- [x] Route controller logs show correct ENI for multi-NIC
- [x] VPC route table verified via AWS CLI

**Release note**:

```feature user
Support VPC route creation for instances with multiple network interfaces (EFA-enabled GPU instances)
```