### PR TITLE
chore: enable renovate with automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "extends": [
+    "config:recommended",
+    "github>gardener/ci-infra//config/renovate/automerge-with-tide.json5"
+  ],
+  "labels": ["kind/enhancement"],
+  "postUpdateOptions": ["gomodTidy"],
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchDatasources": ["docker", "go-version"],
+      "matchPackagePatterns": ["golang"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["gomod"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": [
+        "^actions/checkout$",
+        "^actions/setup-go$",
+      ],
+      "automerge": true
+    },
+    {
+      // Ignore paths which most likely create false positives.
+      "matchFileNames": [
+        "chart/**",
+        "cmd/**",
+        "pkg/**",
+        "test/**",
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Enable renovate with automerge in favor of dependabot
- After migration, dependabot.yaml can be removed and dependencies will be bumped automatically

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
