### PR TITLE
Add anluerz to aws-custom-route-controller reviewers and approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,6 +8,7 @@ aliases:
   - kon-angelo
   - MartinWeindel
   - ScheererJ
+  - anluerz
   aws-custom-route-controller-approvers:
   - axel7born
   - DockToFuture
@@ -15,3 +16,4 @@ aliases:
   - kon-angelo
   - MartinWeindel
   - ScheererJ
+  - anluerz


### PR DESCRIPTION
Adds `anluerz` to the `-reviewers` and `-approvers` lists in `OWNERS_ALIASES`.